### PR TITLE
Add nils suggestions for performance

### DIFF
--- a/fstream-usage/src/main/java/io/alex538/fstream/usage/FCollectionWithConfiguration.java
+++ b/fstream-usage/src/main/java/io/alex538/fstream/usage/FCollectionWithConfiguration.java
@@ -14,7 +14,7 @@ public class FCollectionWithConfiguration {
         FCollection<UUID> collection =
                 FCollection.builder()
                         .serializer(new FstSerializer())
-                        .storageLocation("/tmp")
+                        .storageLocation(System.getProperty("java.io.tmpdir"))
                         .externalSortingMaxItemsInMemory(300)
                         .build()
                 ;

--- a/fstream-usage/src/test/java/io/alex538/fstream/usage/FCollectionWithConfigurationTest.java
+++ b/fstream-usage/src/test/java/io/alex538/fstream/usage/FCollectionWithConfigurationTest.java
@@ -1,0 +1,12 @@
+package io.alex538.fstream.usage;
+
+import org.junit.jupiter.api.Test;
+
+class FCollectionWithConfigurationTest {
+
+    @Test
+    public void test() throws Exception {
+        FCollectionWithConfiguration.main(null);
+    }
+
+}

--- a/fstream/src/main/java/io/alex538/fstream/FCollection.java
+++ b/fstream/src/main/java/io/alex538/fstream/FCollection.java
@@ -76,7 +76,7 @@ public interface FCollection<T extends Serializable> extends AutoCloseable {
      * */
     class Builder {
 
-        private static final String DEFAULT_STORAGE_PATH = "/tmp";
+        private static final String DEFAULT_STORAGE_PATH = System.getProperty("java.io.tmpdir");
 
         private static final FSerializer DEFAULT_SERIALIZER = new FJdkSerializer();
 

--- a/fstream/src/main/java/io/alex538/fstream/FFileStorage.java
+++ b/fstream/src/main/java/io/alex538/fstream/FFileStorage.java
@@ -187,6 +187,21 @@ class FInputStream extends InputStream {
         return raf.read();
     }
 
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        raf.seek(pos);
+
+        int remaining = (int) (endOfBlock - pos);
+        if (remaining <= 0) {
+            return -1;
+        }
+
+        int readCount = raf.read(b, off, Math.min(remaining, len));
+        pos += readCount;
+
+        return readCount;
+    }
+
 }
 
 class FOutputStream extends OutputStream {
@@ -198,8 +213,18 @@ class FOutputStream extends OutputStream {
     }
 
     @Override
-    public void write(int b) throws IOException {
-        raf.write(b);
+    public void write(int data) throws IOException {
+        raf.write(data);
+    }
+
+    @Override
+    public void write(byte[] data) throws IOException {
+        raf.write(data);
+    }
+
+    @Override
+    public void write(byte[] data, int off, int len) throws IOException {
+        raf.write(data, off, len);
     }
 
 }

--- a/fstream/src/test/java/io/alex538/fstream/FFileStorageTest.java
+++ b/fstream/src/test/java/io/alex538/fstream/FFileStorageTest.java
@@ -15,7 +15,9 @@ class FFileStorageTest {
 
     @Test
     public void test_String() {
-        try (FFileStorage<String> storage = new FFileStorage<>(new FJdkSerializer(), "/tmp", "storage-1")) {
+        try (FFileStorage<String> storage = new FFileStorage<>(
+                new FJdkSerializer(), System.getProperty("java.io.tmpdir"), "storage-1"
+        )) {
 
             storage.write("1234567890");
             storage.write("2345678901");
@@ -32,7 +34,9 @@ class FFileStorageTest {
     }
     @Test
     public void test_TestDto() {
-        try (FFileStorage<TestDto> storage = new FFileStorage<>(new FJdkSerializer(), "/tmp", "storage-1")) {
+        try (FFileStorage<TestDto> storage = new FFileStorage<>(
+                new FJdkSerializer(), System.getProperty("java.io.tmpdir"), "storage-1"
+        )) {
             var sample1 = new TestDto(100, 400);
             var sample2 = new TestDto(200, 500);
             var sample3 = new TestDto(300, 600);


### PR DESCRIPTION
Performance improvements:
- Implement `write(byte[])` and `write(byte[], int, int)` methods for FOutputStream
- implement `read(byte[], int, int)` method for FInputStream

Temporary directory:
- by default a storage is create in a system's temporary directory which location is read from `System.getProperty("java.io.tmpdir")`